### PR TITLE
refactor: split Mapper into DtoMapper and EntityMapper for  better separation of concerns

### DIFF
--- a/app/src/main/java/com/example/airline/location/airport/api/AirportController.java
+++ b/app/src/main/java/com/example/airline/location/airport/api/AirportController.java
@@ -7,7 +7,7 @@ import java.util.Locale;
 import java.util.Optional;
 
 import com.example.airline.airport.AirportDTO;
-import com.example.airline.location.airport.mapper.AirportMapper;
+import com.example.airline.location.airport.mapper.DtoMapper;
 import com.example.airline.location.airport.model.Airport;
 import com.example.airline.location.airport.service.AirportService;
 import com.example.airline.location.config.GlobalApiResponses;
@@ -40,9 +40,9 @@ public class AirportController
 {
     // Autowired via constructor
     private final AirportService service;
-    private final AirportMapper  mapper;
+    private final DtoMapper      mapper;
 
-    public AirportController( final AirportService service, final AirportMapper mapper )
+    public AirportController( final AirportService service, final DtoMapper mapper )
     {
         this.service = service;
         this.mapper  = mapper;
@@ -141,7 +141,7 @@ public class AirportController
      *         criteria.
      */
     @GetMapping( path = "/search" )
-    public Page<AirportDTO> advancedQuery( @RequestParam( name = "iataCode", required = false ) final String iataCode,
+    public Page<AirportDTO> ßadvancedQuery( @RequestParam( name = "iataCode", required = false ) final String iataCode,
                                            @RequestParam( name = "icaoCode", required = false ) final String icaoCode,
                                            @RequestParam( name = "ident", required = false ) final String ident,
                                            @RequestParam( name = "name", required = false ) final String name,

--- a/app/src/main/java/com/example/airline/location/airport/mapper/DtoMapper.java
+++ b/app/src/main/java/com/example/airline/location/airport/mapper/DtoMapper.java
@@ -1,0 +1,34 @@
+/* (C) 2025 */
+
+package com.example.airline.location.airport.mapper;
+
+
+import java.util.List;
+
+import com.example.airline.airport.AirportDTO;
+import com.example.airline.location.airport.model.Airport;
+import com.example.airline.location.persistence.model.airport.AirportEntity;
+import org.mapstruct.Mapper;
+
+
+/**
+ * MapStruct configuration for Airport, AirportDTO.
+ */
+@Mapper( componentModel = "spring" )
+public interface DtoMapper
+{
+    // ------------------------
+    // ----- Domain / API -----
+    // --- Domain --> API ---
+    // --- Instance
+    /** Map a domain instance to an API instance. */
+    AirportDTO domainToApi( Airport airport );
+
+    // --- Collection
+    /** Map a list of domain instances to a list of API instances. */
+    List<AirportDTO> domainToApi( List<Airport> airports );
+
+    // --- API --> Domain ---
+    // --- Instance
+    // --- Collection
+}

--- a/app/src/main/java/com/example/airline/location/airport/mapper/EntityMapper.java
+++ b/app/src/main/java/com/example/airline/location/airport/mapper/EntityMapper.java
@@ -9,17 +9,14 @@ import com.example.airline.airport.AirportDTO;
 import com.example.airline.location.airport.model.Airport;
 import com.example.airline.location.persistence.model.airport.AirportEntity;
 import org.mapstruct.Mapper;
-import org.mapstruct.factory.Mappers;
 
 
 /**
- * MapStruct configuration for Airport, AirportEntity, AirportDTO.
+ * MapStruct configuration for Airport, AirportEntity.
  */
 @Mapper( componentModel = "spring" )
-public interface AirportMapper
+public interface EntityMapper
 {
-//    AirportMapper INSTANCE = Mappers.getMapper( AirportMapper.class );
-
     // --------------------------------
     // ----- Domain / Persistence -----
     // --- Persistence --> Domain ---
@@ -32,21 +29,6 @@ public interface AirportMapper
     List<Airport> entityToDomain( List<AirportEntity> entities );
 
     // --- Domain --> Persistence ---
-    // --- Instance
-    // --- Collection
-
-    // ------------------------
-    // ----- Domain / API -----
-    // --- Domain --> API ---
-    // --- Instance
-    /** Map a domain instance to an API instance. */
-    AirportDTO domainToApi( Airport airport );
-
-    // --- Collection
-    /** Map a list of domain instances to a list of API instances. */
-    List<AirportDTO> domainToApi( List<Airport> airports );
-
-    // --- API --> Domain ---
     // --- Instance
     // --- Collection
 }

--- a/app/src/main/java/com/example/airline/location/airport/service/AirportService.java
+++ b/app/src/main/java/com/example/airline/location/airport/service/AirportService.java
@@ -5,10 +5,10 @@ package com.example.airline.location.airport.service;
 
 import java.util.Optional;
 
+import com.example.airline.location.airport.mapper.EntityMapper;
 import com.example.airline.location.airport.model.Airport;
-import com.example.airline.location.airport.mapper.AirportMapper;
-import com.example.airline.location.persistence.model.airport.AirportEntity;
 import com.example.airline.location.airport.persistence.repository.AirportRepository;
+import com.example.airline.location.persistence.model.airport.AirportEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -23,7 +23,7 @@ public class AirportService
 {
     private final AirportRepository repository;
 
-    private final AirportMapper mapper;
+    private final EntityMapper mapper;
 
     /**
      * Create a AirportService supported by autowire.
@@ -31,7 +31,7 @@ public class AirportService
      * @param repository jpa repository of Airports
      * @param mapper maps entities to/from the domain model
      */
-    public AirportService( final AirportRepository repository, final AirportMapper mapper )
+    public AirportService( final AirportRepository repository, final EntityMapper mapper )
     {
         this.repository = repository;
         this.mapper     = mapper;
@@ -121,7 +121,7 @@ public class AirportService
             return Optional.of( mapper.entityToDomain( entity.get() ) );
         }
 
-        return Optional.ofNullable( null );
+        return Optional.empty();
     }
 
 }

--- a/app/src/main/java/com/example/airline/location/continent/api/ContinentController.java
+++ b/app/src/main/java/com/example/airline/location/continent/api/ContinentController.java
@@ -12,7 +12,7 @@ import com.example.airline.location.ContinentDTO;
 import com.example.airline.location.NewContinentDTO;
 import com.example.airline.location.config.GlobalApiResponses;
 import com.example.airline.location.config.GlobalApiSecurityResponses;
-import com.example.airline.location.continent.mapper.ContinentMapper;
+import com.example.airline.location.continent.mapper.DtoMapper;
 import com.example.airline.location.continent.model.Continent;
 import com.example.airline.location.continent.service.ContinentService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -56,8 +56,7 @@ public class ContinentController
 {
     // Autowired via constructor
     private final ContinentService service;
-    private final ContinentMapper  mapper;
-//    private final List<MediaType> restMediaTypes = List.of( MediaType.APPLICATION_JSON, MediaType.APPLICATION_YAML );
+    private final DtoMapper        mapper;
 
 
     /**
@@ -66,7 +65,7 @@ public class ContinentController
      * @param service The service to use for continent operations.
      * @param mapper  The mapper to convert between domain and API objects.
      */
-    public ContinentController( final ContinentService service, final ContinentMapper mapper )
+    public ContinentController( final ContinentService service, final DtoMapper mapper )
     {
         this.service = service;
         this.mapper  = mapper;

--- a/app/src/main/java/com/example/airline/location/continent/mapper/DtoMapper.java
+++ b/app/src/main/java/com/example/airline/location/continent/mapper/DtoMapper.java
@@ -1,0 +1,44 @@
+/* (C) 2025 */
+
+package com.example.airline.location.continent.mapper;
+
+
+import java.util.List;
+
+import com.example.airline.location.ContinentDTO;
+import com.example.airline.location.NewContinentDTO;
+import com.example.airline.location.continent.model.Continent;
+import com.example.airline.location.continent.model.NewContinent;
+import org.mapstruct.Mapper;
+
+
+/**
+ * MapStruct configuration for Continent, ContinentEntity, ContinentDTO.
+ */
+@Mapper( componentModel = "spring" )
+public interface DtoMapper
+{
+    // ------------------------
+    // ----- Domain / API -----
+    // --- Domain --> API ---
+    // --- Instance
+
+    /**
+     * Map a domain instance to an API instance.
+     */
+    ContinentDTO domainToApi( Continent continent );
+
+    // --- Collection
+
+    /**
+     * Map a list of domain instances to a list of API instances.
+     */
+    List<ContinentDTO> domainToApi( List<Continent> continents );
+
+    // --- API --> Domain ---
+    // --- Instance
+    Continent apiToDomain( ContinentDTO dto );
+
+    NewContinent apiToDomain( NewContinentDTO dto );
+    // --- Collection
+}

--- a/app/src/main/java/com/example/airline/location/continent/mapper/EntityMapper.java
+++ b/app/src/main/java/com/example/airline/location/continent/mapper/EntityMapper.java
@@ -5,8 +5,6 @@ package com.example.airline.location.continent.mapper;
 
 import java.util.List;
 
-import com.example.airline.location.ContinentDTO;
-import com.example.airline.location.NewContinentDTO;
 import com.example.airline.location.continent.model.Continent;
 import com.example.airline.location.continent.model.NewContinent;
 import com.example.airline.location.continent.persistence.model.ContinentEntity;
@@ -17,7 +15,7 @@ import org.mapstruct.Mapper;
  * MapStruct configuration for Continent, ContinentEntity, ContinentDTO.
  */
 @Mapper( componentModel = "spring" )
-public interface ContinentMapper
+public interface EntityMapper
 {
     //ContinentMapper INSTANCE = Mappers.getMapper( ContinentMapper.class );
 
@@ -46,27 +44,27 @@ public interface ContinentMapper
     ContinentEntity domainToEntity( NewContinent domain );
     // --- Collection
 
-    // ------------------------
-    // ----- Domain / API -----
-    // --- Domain --> API ---
-    // --- Instance
-
-    /**
-     * Map a domain instance to an API instance.
-     */
-    ContinentDTO domainToApi( Continent continent );
-
-    // --- Collection
-
-    /**
-     * Map a list of domain instances to a list of API instances.
-     */
-    List<ContinentDTO> domainToApi( List<Continent> continents );
-
-    // --- API --> Domain ---
-    // --- Instance
-    Continent apiToDomain( ContinentDTO dto );
-
-    NewContinent apiToDomain( NewContinentDTO dto );
-    // --- Collection
+//    // ------------------------
+//    // ----- Domain / API -----
+//    // --- Domain --> API ---
+//    // --- Instance
+//
+//    /**
+//     * Map a domain instance to an API instance.
+//     */
+//    ContinentDTO domainToApi( Continent continent );
+//
+//    // --- Collection
+//
+//    /**
+//     * Map a list of domain instances to a list of API instances.
+//     */
+//    List<ContinentDTO> domainToApi( List<Continent> continents );
+//
+//    // --- API --> Domain ---
+//    // --- Instance
+//    Continent apiToDomain( ContinentDTO dto );
+//
+//    NewContinent apiToDomain( NewContinentDTO dto );
+//    // --- Collection
 }

--- a/app/src/main/java/com/example/airline/location/continent/service/ContinentService.java
+++ b/app/src/main/java/com/example/airline/location/continent/service/ContinentService.java
@@ -6,7 +6,7 @@ package com.example.airline.location.continent.service;
 import java.util.List;
 import java.util.Optional;
 
-import com.example.airline.location.continent.mapper.ContinentMapper;
+import com.example.airline.location.continent.mapper.EntityMapper;
 import com.example.airline.location.continent.model.Continent;
 import com.example.airline.location.continent.model.NewContinent;
 import com.example.airline.location.continent.persistence.model.ContinentEntity;
@@ -24,7 +24,7 @@ public class ContinentService
 {
     private final ContinentRepository repository;
 
-    private final ContinentMapper mapper;
+    private final EntityMapper mapper;
 
     /**
      * Create a ContinentService supported by autowire.
@@ -32,7 +32,7 @@ public class ContinentService
      * @param repository jpa repository of Continents
      * @param mapper     maps entities to/from the domain model
      */
-    public ContinentService( final ContinentRepository repository, final ContinentMapper mapper )
+    public ContinentService( final ContinentRepository repository, final EntityMapper mapper )
     {
         this.repository = repository;
         this.mapper     = mapper;

--- a/app/src/main/java/com/example/airline/location/country/api/CountryController.java
+++ b/app/src/main/java/com/example/airline/location/country/api/CountryController.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import com.example.airline.location.CountryDTO;
 import com.example.airline.location.config.GlobalApiResponses;
 import com.example.airline.location.config.GlobalApiSecurityResponses;
-import com.example.airline.location.country.mapper.CountryMapper;
+import com.example.airline.location.country.mapper.DtoMapper;
 import com.example.airline.location.country.model.Country;
 import com.example.airline.location.country.service.CountryService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -47,7 +47,7 @@ public class CountryController
 {
     // Autowired via constructor
     private final CountryService service;
-    private final CountryMapper  mapper;
+    private final DtoMapper      mapper;
 
     /**
      * Constructor for the CountryController.
@@ -55,7 +55,7 @@ public class CountryController
      * @param service The service to use for country operations.
      * @param mapper  The mapper to convert between domain and API objects.
      */
-    public CountryController( final CountryService service, final CountryMapper mapper )
+    public CountryController( final CountryService service, final DtoMapper mapper )
     {
         this.service = service;
         this.mapper  = mapper;

--- a/app/src/main/java/com/example/airline/location/country/mapper/DtoMapper.java
+++ b/app/src/main/java/com/example/airline/location/country/mapper/DtoMapper.java
@@ -9,40 +9,16 @@ import com.example.airline.location.CountryDTO;
 import com.example.airline.location.country.model.Country;
 import com.example.airline.location.persistence.model.location.CountryEntity;
 import org.mapstruct.Mapper;
-import org.mapstruct.factory.Mappers;
 
 
 /**
- * MapStruct configuration for Country, CountryEntity, CountryDTO.
+ * MapStruct configuration for Country, CountryDTO.
  * <p>
  * Mapstruct will generate the methods.
  */
 @Mapper( componentModel = "spring" )
-public interface CountryMapper
+public interface DtoMapper
 {
-//    CountryMapper INSTANCE = Mappers.getMapper( CountryMapper.class );
-
-    // --------------------------------
-    // ----- Domain / Persistence -----
-    // --- Persistence --> Domain ---
-    // --- Instance
-
-    /**
-     * Map a single db entity instance to a domain instance.
-     */
-    Country entityToDomain( CountryEntity entity );
-
-    // --- Collection
-
-    /**
-     * Map a list of domain instances to a list of db entity instances.
-     */
-    List<Country> entityToDomain( List<CountryEntity> entities );
-
-    // --- Domain --> Persistence ---
-    // --- Instance
-    // --- Collection
-
     // ------------------------
     // ----- Domain / API -----
     // --- Domain --> API ---

--- a/app/src/main/java/com/example/airline/location/country/mapper/EntityMapper.java
+++ b/app/src/main/java/com/example/airline/location/country/mapper/EntityMapper.java
@@ -1,0 +1,65 @@
+/* (C) 2025 */
+
+package com.example.airline.location.country.mapper;
+
+
+import java.util.List;
+
+import com.example.airline.location.CountryDTO;
+import com.example.airline.location.country.model.Country;
+import com.example.airline.location.persistence.model.location.CountryEntity;
+import org.mapstruct.Mapper;
+
+
+/**
+ * MapStruct configuration for Country, CountryEntity.
+ * <p>
+ * Mapstruct will generate the methods.
+ */
+@Mapper( componentModel = "spring" )
+public interface EntityMapper
+{
+//    CountryMapper INSTANCE = Mappers.getMapper( CountryMapper.class );
+
+    // --------------------------------
+    // ----- Domain / Persistence -----
+    // --- Persistence --> Domain ---
+    // --- Instance
+
+    /**
+     * Map a single db entity instance to a domain instance.
+     */
+    Country entityToDomain( CountryEntity entity );
+
+    // --- Collection
+
+    /**
+     * Map a list of domain instances to a list of db entity instances.
+     */
+    List<Country> entityToDomain( List<CountryEntity> entities );
+
+    // --- Domain --> Persistence ---
+    // --- Instance
+    // --- Collection
+
+    // ------------------------
+    // ----- Domain / API -----
+    // --- Domain --> API ---
+    // --- Instance
+
+    /**
+     * Map a domain instance to an API instance.
+     */
+    CountryDTO domainToApi( Country country );
+
+    // --- Collection
+
+    /**
+     * Map a list of domain instances to a list of API instances.
+     */
+    List<CountryDTO> domainToApi( List<Country> countrys );
+
+    // --- API --> Domain ---
+    // --- Instance
+    // --- Collection
+}

--- a/app/src/main/java/com/example/airline/location/country/service/CountryService.java
+++ b/app/src/main/java/com/example/airline/location/country/service/CountryService.java
@@ -5,8 +5,8 @@ package com.example.airline.location.country.service;
 
 import java.util.Optional;
 
+import com.example.airline.location.country.mapper.EntityMapper;
 import com.example.airline.location.country.model.Country;
-import com.example.airline.location.country.mapper.CountryMapper;
 import com.example.airline.location.persistence.model.location.CountryEntity;
 import com.example.airline.location.country.persistence.repository.CountryRepository;
 import org.springframework.data.domain.Page;
@@ -23,7 +23,7 @@ public class CountryService
 {
     private final CountryRepository repository;
 
-    private final CountryMapper mapper;
+    private final EntityMapper mapper;
 
     /**
      * Create a CountryService supported by autowire.
@@ -31,7 +31,7 @@ public class CountryService
      * @param repository jpa repository of Countries
      * @param mapper maps entities to/from the domain model
      */
-    public CountryService( final CountryRepository repository, final CountryMapper mapper )
+    public CountryService( final CountryRepository repository, final EntityMapper mapper )
     {
         this.repository = repository;
         this.mapper     = mapper;
@@ -72,7 +72,7 @@ public class CountryService
             return Optional.of( country );
         }
 
-        return Optional.ofNullable( null );
+        return Optional.empty();
     }
 
 
@@ -94,7 +94,7 @@ public class CountryService
             return Optional.of( country );
         }
 
-        return Optional.ofNullable( null );
+        return Optional.empty();
     }
 
 }

--- a/app/src/main/java/com/example/airline/location/region/api/RegionsController.java
+++ b/app/src/main/java/com/example/airline/location/region/api/RegionsController.java
@@ -9,7 +9,7 @@ import com.example.airline.location.region.model.Region;
 import com.example.airline.location.RegionDTO;
 import com.example.airline.location.config.GlobalApiResponses;
 import com.example.airline.location.config.GlobalApiSecurityResponses;
-import com.example.airline.location.region.mapper.RegionMapper;
+import com.example.airline.location.region.mapper.DtoMapper;
 import com.example.airline.location.region.service.RegionsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -47,7 +47,7 @@ public class RegionsController
 {
     // Autowired via constructor
     private final RegionsService service;
-    private final RegionMapper   mapper;
+    private final DtoMapper      mapper;
 
     /**
      * Constructor for the RegionsController.
@@ -55,7 +55,7 @@ public class RegionsController
      * @param service The service to use for region operations.
      * @param mapper  The mapper to convert between domain and API objects.
      */
-    public RegionsController( final RegionsService service, final RegionMapper mapper )
+    public RegionsController( final RegionsService service, final DtoMapper mapper )
     {
         this.service = service;
         this.mapper  = mapper;

--- a/app/src/main/java/com/example/airline/location/region/mapper/DtoMapper.java
+++ b/app/src/main/java/com/example/airline/location/region/mapper/DtoMapper.java
@@ -1,0 +1,34 @@
+/* (C) 2025 */
+
+package com.example.airline.location.region.mapper;
+
+
+import java.util.List;
+
+import com.example.airline.location.RegionDTO;
+import com.example.airline.location.persistence.model.location.RegionEntity;
+import com.example.airline.location.region.model.Region;
+import org.mapstruct.Mapper;
+
+
+/**
+ * MapStruct configuration for Region, RegionDTO.
+ */
+@Mapper( componentModel = "spring" )
+public interface DtoMapper
+{
+    // ------------------------
+    // ----- Domain / API -----
+    // --- Domain --> API ---
+    // --- Instance
+    /** Map a domain instance to an API instance. */
+    RegionDTO domainToApi( Region region );
+
+    // --- Collection
+    /** Map a list of domain instances to a list of API instances. */
+    List<RegionDTO> domainToApi( List<Region> regions );
+
+    // --- API --> Domain ---
+    // --- Instance
+    // --- Collection
+}

--- a/app/src/main/java/com/example/airline/location/region/mapper/EntityMapper.java
+++ b/app/src/main/java/com/example/airline/location/region/mapper/EntityMapper.java
@@ -5,22 +5,18 @@ package com.example.airline.location.region.mapper;
 
 import java.util.List;
 
-import com.example.airline.location.region.model.Region;
 import com.example.airline.location.RegionDTO;
 import com.example.airline.location.persistence.model.location.RegionEntity;
+import com.example.airline.location.region.model.Region;
 import org.mapstruct.Mapper;
-import org.mapstruct.factory.Mappers;
-
 
 
 /**
- * MapStruct configuration for Region, RegionEntity, RegionDTO.
+ * MapStruct configuration for Region, RegionEntity.
  */
 @Mapper( componentModel = "spring" )
-public interface RegionMapper
+public interface EntityMapper
 {
-//    RegionMapper INSTANCE = Mappers.getMapper( RegionMapper.class );
-
     // --------------------------------
     // ----- Domain / Persistence -----
     // --- Persistence --> Domain ---
@@ -33,23 +29,6 @@ public interface RegionMapper
     List<Region> entityToDomain( List<RegionEntity> dtos );
 
     // --- Domain --> Persistence ---
-    // --- Instance
-    // --- Collection
-
-    // ------------------------
-    // ----- Domain / API -----
-    // --- Domain --> API ---
-    // --- Instance
-    /** Map a domain instance to an API instance. */
-    RegionDTO domainToApi( Region region );
-
-    // --- Collection
-    /** Map a list of domain instances to a list of API instances. */
-    List<RegionDTO> domainToApi( List<Region> regions );
-
-//    <T,S> T entityToDomain( S s );
-
-    // --- API --> Domain ---
     // --- Instance
     // --- Collection
 }

--- a/app/src/main/java/com/example/airline/location/region/service/RegionsService.java
+++ b/app/src/main/java/com/example/airline/location/region/service/RegionsService.java
@@ -6,7 +6,7 @@ package com.example.airline.location.region.service;
 import java.util.Optional;
 
 import com.example.airline.location.persistence.model.location.RegionEntity;
-import com.example.airline.location.region.mapper.RegionMapper;
+import com.example.airline.location.region.mapper.EntityMapper;
 import com.example.airline.location.region.model.Region;
 import com.example.airline.location.region.persistence.repository.RegionsRepository;
 import org.springframework.data.domain.Page;
@@ -22,7 +22,7 @@ public class RegionsService
 {
     private final RegionsRepository repository;
 
-    private final RegionMapper mapper;
+    private final EntityMapper mapper;
 
     /**
      * Create a RegionService supported by autowire.
@@ -30,7 +30,7 @@ public class RegionsService
      * @param repository jpa repository of Regions
      * @param mapper maps entities to/from the domain model
      */
-    public RegionsService( final RegionsRepository repository, final RegionMapper mapper )
+    public RegionsService( final RegionsRepository repository, final EntityMapper mapper )
     {
         this.repository = repository;
         this.mapper     = mapper;
@@ -90,7 +90,7 @@ public class RegionsService
             return Optional.of( item );
         }
 
-        return Optional.ofNullable( null );
+        return Optional.empty();
     }
 
 

--- a/app/src/main/java/com/example/rest/exception/GlobalExceptionHandler.java
+++ b/app/src/main/java/com/example/rest/exception/GlobalExceptionHandler.java
@@ -311,6 +311,8 @@ public class GlobalExceptionHandler
     @ResponseStatus( code = HttpStatus.BAD_REQUEST )
     public ResponseEntity<ProblemDetail> handleMessageNotReadableException( final HttpMessageNotReadableException exception )
     {
+        // TODO potentially a problem with the content-type or lack of mapping to/from the
+        // requested format and the internal POJO.
         final ProblemDetail details = ProblemDetail.forStatusAndDetail( HttpStatus.BAD_REQUEST,
                                                                         exception.getMessage() );
 

--- a/app/src/test/java/com/example/airline/location/airport/api/AirportControllerRestTest.java
+++ b/app/src/test/java/com/example/airline/location/airport/api/AirportControllerRestTest.java
@@ -18,7 +18,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
-import com.example.airline.location.airport.mapper.AirportMapper;
+import com.example.airline.location.airport.mapper.DtoMapper;
 import com.example.airline.location.airport.persistence.repository.AirportRepository;
 import com.example.airline.location.airport.service.AirportService;
 import com.example.airline.location.persistence.model.airport.AirportEntity;
@@ -56,7 +56,7 @@ class AirportControllerRestTest //extends RestControllerTestBase
     @Autowired
     private AirportService service;
     @Autowired
-    private AirportMapper mapper;
+    private DtoMapper mapper;
 
 
 //    @BeforeEach

--- a/app/src/test/java/com/example/airline/location/continent/api/ContinentControllerRestTest.java
+++ b/app/src/test/java/com/example/airline/location/continent/api/ContinentControllerRestTest.java
@@ -28,7 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.List;
 import java.util.Optional;
 
-import com.example.airline.location.continent.mapper.ContinentMapper;
+import com.example.airline.location.continent.mapper.DtoMapper;
 import com.example.airline.location.continent.persistence.model.ContinentEntity;
 import com.example.airline.location.continent.persistence.repository.ContinentRepository;
 import com.example.airline.location.continent.service.ContinentService;
@@ -110,7 +110,7 @@ class ContinentControllerRestTest
 
     @Autowired
     @SuppressWarnings( "unused" )
-    private ContinentMapper mapper;
+    private DtoMapper mapper;
 
     @MockitoBean
     private ContinentRepository repository;

--- a/app/src/test/java/com/example/airline/location/country/api/CountryControllerRestTest.java
+++ b/app/src/test/java/com/example/airline/location/country/api/CountryControllerRestTest.java
@@ -17,9 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.List;
 import java.util.Optional;
 
-import com.example.airline.location.country.mapper.CountryMapper;
 import com.example.airline.location.country.persistence.repository.CountryRepository;
-import com.example.airline.location.country.service.CountryService;
 import com.example.airline.location.persistence.model.location.CountryEntity;
 import com.example.rest.utility.PageableAssert;
 import org.junit.jupiter.api.DisplayName;
@@ -50,10 +48,10 @@ class CountryControllerRestTest //extends RestControllerTestBase
     protected MockMvc mvc;
     @MockitoBean
     protected CountryRepository repository;
-    @Autowired
-    private CountryService service;
-    @Autowired
-    private CountryMapper mapper;
+//    @Autowired
+//    private CountryService service;
+//    @Autowired
+//    private DtoMapper mapper;
 
 
 //    @BeforeEach
@@ -155,15 +153,6 @@ class CountryControllerRestTest //extends RestControllerTestBase
                     .andExpect( jsonPath( "$.keywords" ).doesNotExist() )
                     .andReturn();
             MockHttpServletResponse response = result.getResponse();
-            String jsonString =
-                    """
-                            {
-                               "id": 2,
-                               "code: "XXX",
-                               "name": "::NAME::",
-                               "continent": "NA"
-                            }
-                            """;
 
             // --- then
             // TODO need to assert the resulting JSON....
@@ -231,26 +220,6 @@ class CountryControllerRestTest //extends RestControllerTestBase
                     .andExpect( jsonPath( "$.content[0].keywords" ).doesNotExist() )
                     .andReturn();
             final MockHttpServletResponse response = result.getResponse();
-            final String jsonString =
-                    """
-                            [
-                                {
-                                   "id": 1,
-                                   "code: "XX",
-                                   "name": "::XNAMEX::"
-                                },
-                                {
-                                   "id": 2,
-                                   "code: "YY",
-                                   "name": "::YNAMEY::"
-                                },
-                                {
-                                   "id": 3,
-                                   "code: "ZZ",
-                                   "name": "::ZNAMEZ::"
-                                }
-                            ]
-                            """;
 
             // --- then
             // TODO need to assert the resulting JSON....

--- a/app/src/test/java/com/example/airline/location/region/api/RegionControllerRestTest.java
+++ b/app/src/test/java/com/example/airline/location/region/api/RegionControllerRestTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.example.airline.location.persistence.model.location.RegionEntity;
-import com.example.airline.location.region.mapper.RegionMapper;
+import com.example.airline.location.region.mapper.DtoMapper;
 import com.example.airline.location.region.persistence.repository.RegionsRepository;
 import com.example.airline.location.region.service.RegionsService;
 import com.example.rest.utility.PageableAssert;
@@ -53,7 +53,7 @@ class RegionControllerRestTest //extends RestControllerTestBase
     @Autowired
     private RegionsService service;
     @Autowired
-    private RegionMapper mapper;
+    private DtoMapper      mapper;
 
 
     @Nested


### PR DESCRIPTION
Split the existing Mapper definitions which included both DTO to Domain and Domain to Entity(persistence) into separate classes.  This decouples the REST API from the Persistence layers better.. Remove an artificial coupling via the Mapper class.