### PR TITLE
Feature/update for ddl validate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,12 @@ hs_err_pid*
 **/bin/
 build-logic/bin/**
 
+# Multi-project layout
+/app/build/
+/api/build/
+/lib/build/
+/build-logic/build/
+
 # Ignore Gradle GUI config
 gradle-app.setting
 
@@ -76,10 +82,3 @@ mysql-connector-*
 # PMD
 .pmdCache
 
-# Gradle project layout
-
-/app/build/
-/api/build/
-/lib/build/
-/build-logic/build/
-/build/

--- a/api/src/main/java/com/example/airline/airport/AirportDTO.java
+++ b/api/src/main/java/com/example/airline/airport/AirportDTO.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -23,6 +24,7 @@ import org.jspecify.annotations.Nullable;
  */
 @Data
 @AllArgsConstructor
+@Builder
 public class AirportDTO
 {
     /**
@@ -54,7 +56,7 @@ public class AirportDTO
              example = "KORD" )
     @NotBlank( message = "A 4 to 7 character airport ident code is required" )
     @lombok.NonNull
-    @Pattern( regexp = "(([A-Z]{3,4})|([A-Z]{2}[0-9]{2})|([A-Z]{2}-[0-9]{4}))",
+    @Pattern( regexp = "(([A-Z]{3,4})|([A-Z]{2}\\d{2})|([A-Z]{2}-\\d{4}))",
               message = "Airport ident must a unique 4 to 7 character code following a specific pattern" )
     private String ident;  // char-8
 
@@ -192,9 +194,9 @@ public class AirportDTO
                      ICAO codes, assigned by the International Civil Aviation
                      Organization, are four-letter codes. They’re used globally
                      in flight operations and Air Traffic Control.
-                     
-                     The International Air Transport Association issues IATA 
-                     codes. These are the three-letter airport codes travelers 
+
+                     The International Air Transport Association issues IATA
+                     codes. These are the three-letter airport codes travelers
                      are most familiar with. Flight ticketing, baggage handling,
                      and cargo shipping primarily use these codes.
                      """,
@@ -213,7 +215,7 @@ public class AirportDTO
              description = """
                            The International Air Transport Association's (IATA)
                            Location Identifier is a unique 3-letter code
-                           (also commonly known as IATA code) used in aviation 
+                           (also commonly known as IATA code) used in aviation
                            and also in logistics to identify an airport.
                            """,
              example = "ATL",
@@ -229,7 +231,11 @@ public class AirportDTO
      */
     @JsonProperty( "localCode" )
     @Schema( name = "localCode",
-             description = "The local country code for the airport, if different from the gps_code and iata_code fields (used mainly for US airports)",
+             description =
+                """
+                The local country code for the airport, if different from the gps_code
+                and iata_code fields (used mainly for US airports)
+                """,
              example = "ATL",
              requiredMode = Schema.RequiredMode.NOT_REQUIRED,
              maxLength = 7 )

--- a/api/src/main/java/com/example/airline/location/continent/ContinentDTO.java
+++ b/api/src/main/java/com/example/airline/location/continent/ContinentDTO.java
@@ -38,7 +38,7 @@ public class ContinentDTO //implements Serializable
              description = "Unique identifier",
              requiredMode = Schema.RequiredMode.REQUIRED )
     @NotNull( message = "A continent id is required" )
-//    @Pattern( regexp = "[0-9]+", message = "'id' must be only digits" )
+    // @Pattern( regexp = "[0-9]+", message = "'id' must be only digits" )
     private Integer id;
 
     // TODO convert to a Java record
@@ -75,7 +75,7 @@ public class ContinentDTO //implements Serializable
              requiredMode = Schema.RequiredMode.NOT_REQUIRED,
              maxLength = 255 )
     @Nullable
-//    @Size( max = 255, message = "List of keywords may not exceed 255 characters" )
+    // @Size( max = 255, message = "List of keywords may not exceed 255 characters" )
     private URI    wikiLink;
 
     @JsonProperty( "keywords" )

--- a/api/src/main/java/com/example/airline/location/continent/NewContinentDTO.java
+++ b/api/src/main/java/com/example/airline/location/continent/NewContinentDTO.java
@@ -63,7 +63,7 @@ public class NewContinentDTO //implements Serializable
              requiredMode = Schema.RequiredMode.NOT_REQUIRED,
              maxLength = 255 )
     @Nullable
-//    @Size( max = 255, message = "List of keywords may not exceed 255 characters" )
+    // @Size( max = 255, message = "List of keywords may not exceed 255 characters" )
     private URI    wikiLink;
 
     @JsonProperty( "keywords" )

--- a/api/src/main/java/com/example/airline/location/region/RegionDTO.java
+++ b/api/src/main/java/com/example/airline/location/region/RegionDTO.java
@@ -131,7 +131,7 @@ public class RegionDTO
     @NotBlank( message = "An ISO 3166:1-alpha2 country code is required" )
     @NonNull
     @Pattern( regexp = "[A-Z]{2}", message = "Code must a valid ISO 3166:1-alpha2" )
-    private String country; // ! Create domain-object for the country code
+    private String country; // ! Create a domain-object for the country code
 
     /**
      * A code for the continent to which the region belongs. See the continent field
@@ -148,7 +148,7 @@ public class RegionDTO
     @NotBlank( message = "A 2-character continent code is required" )
     @NonNull
     @Pattern( regexp = "[A-Z]{2}", message = "Continent code must be 2 uppercase characters" )
-    private String continent; // ! Create domain-object for continent code
+    private String continent; // ! Create a domain-object for continent code
 
     /**
      * A link to the Wikipedia article describing the subdivision.

--- a/api/src/test/java/com/example/airline/airport/AirportDTOTest.java
+++ b/api/src/test/java/com/example/airline/airport/AirportDTOTest.java
@@ -506,15 +506,6 @@ class AirportDTOTest
                                                                  "Key1, key2" );
                 final Set<ConstraintViolation<AirportDTO>> constraintViolations = validator.validate( itemUnderTest );
 
-//                ConstraintValidationUtility
-//                        .assertConstraintErrors( constraintViolations,
-////                                             tuple( "code", "Code must a valid ISO 3166:1-alpha2 followed by '-' and a local code" ),
-////                                             tuple( "iataCode", "A unique region code is required" ),
-////                                             tuple( "icaoCode", "IACO code has four alpha-numeric characters" ),
-////                                             tuple( "isoCountry", "An ISO 3166:1-alpha2 country code is required" ),
-////                                                 tuple( "ident", "A 4 to 7 character airport ident code is required" ),
-//                                                 tuple( "ident", "ZAirport ident must a unique 4 to 7 character code following a specific pattern" )
-//                                               );
                 assertThat( constraintViolations.size() )
                         .isEqualTo( 0 );
             }
@@ -1222,15 +1213,8 @@ class AirportDTOTest
 
                 ConstraintValidationUtility
                         .assertConstraintErrors( constraintViolations,
-//                                             tuple( "code", "Code must a valid ISO 3166:1-alpha2 followed by '-' and a local code" ),
                                                  tuple( "iataCode", "IATA code has three alphabetic characters" )
-//                                             tuple( "icaoCode", "IACO code has four alpha-numeric characters" ),
-//                                             tuple( "isoCountry", "An ISO 3166:1-alpha2 country code is required" ),
-//                                                 tuple( "ident", "A 4 to 7 character airport ident code is required" ),
-//                                                 tuple( "ident", "ZAirport ident must a unique 4 to 7 character code following a specific pattern" )
                                                );
-//                assertThat( constraintViolations.size() )
-//                        .isEqualTo( 0 );
             }
 
         }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,12 +118,12 @@ application {
 }
 
 
-task integrationTest(type: Test) {
+tasks.register('integrationTest', Test) {
     group = 'Verification'
     description = 'runs the integration tests with Cucumber/Selenium/Karate'
 
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
-    classpath       = sourceSets.integrationTest.runtimeClasspath
+    classpath = sourceSets.integrationTest.runtimeClasspath
 
     mustRunAfter test
     useJUnitPlatform()

--- a/app/src/main/java/com/example/airline/location/airport/model/Airport.java
+++ b/app/src/main/java/com/example/airline/location/airport/model/Airport.java
@@ -28,7 +28,7 @@ public class Airport
     /**
      * The text identifier used in the OurAirports URL. This will be the ICAO code
      * if available. Otherwise, it will be a local airport code (if no conflict), or
-     * if nothing else is available, an internally-generated code starting with the
+     * if nothing else is available, an internally generated code starting with the
      * ISO2 country code, followed by a dash and a four-digit number.
      */
     @NonNull private String ident;
@@ -76,7 +76,7 @@ public class Airport
 
     /**
      * 'An alphanumeric code for the high-level administrative subdivision of a
-     * country where the airport is primarily located (e.g. province, governorate),
+     * country where the airport is primarily located (e.g., province, governorate),
      * prefixed by the ISO2 country code and a hyphen. OurAirports uses ISO 3166:2
      * codes whenever possible, preferring higher administrative levels, but also
      * includes some custom codes. See the documentation for regions.csv.'
@@ -91,7 +91,7 @@ public class Airport
     @Nullable private String municipality;
 
     /**
-     * "yes" if the airport currently has scheduled airline service; "no" otherwise.
+     * "yes" if the airport currently has scheduled airline service, "no" otherwise.
      */
     @NonNull private String scheduledService; // boolean...
 
@@ -130,7 +130,7 @@ public class Airport
     @Nullable private URI wikipediaLink; // URI
 
     /**
-     * Extra keywords/phrases to assist with search, comma-separated. May include
+     * Extra keywords/phrases to help with search, comma-separated. May include
      * former names for the airport, alternate codes, names in other languages,
      * nearby tourist destinations, etc.
      */

--- a/app/src/main/java/com/example/airline/location/airport/service/AirportService.java
+++ b/app/src/main/java/com/example/airline/location/airport/service/AirportService.java
@@ -26,7 +26,7 @@ public class AirportService
     private final AirportEntityMapper mapper;
 
     /**
-     * Create a AirportService supported by autowire.
+     * Create an AirportService supported by autowire.
      *
      * @param repository jpa repository of Airports
      * @param mapper maps entities to/from the domain model

--- a/app/src/main/java/com/example/airline/location/continent/api/ContinentController.java
+++ b/app/src/main/java/com/example/airline/location/continent/api/ContinentController.java
@@ -194,19 +194,24 @@ public class ContinentController
     @Operation( method = "GET",
                 summary = "Find a Continent by its abbreviation",
                 description = "Find a Continent by its 2 letter code",
-                responses = { @ApiResponse( description = "Continent found and returned",
-                                            responseCode = "200",
-                                            content = { @Content( mediaType = "application/json",
-                                                                  schema = @Schema( implementation = ContinentDTO.class ) ),
-                                                        @Content( mediaType = "application/yaml",
-                                                                  schema = @Schema( implementation = ContinentDTO.class ) ),
-                                                        @Content( mediaType = "application/xml",
-                                                                  schema = @Schema( implementation = ContinentDTO.class ) )
-                                            }
-                                        )
-                            },
+                responses = {
+                    @ApiResponse( description = "Continent found and returned",
+                                  responseCode = "200",
+                                  content = {
+                                      @Content( mediaType = "application/json",
+                                                schema = @Schema( implementation = ContinentDTO.class ) ),
+                                      @Content( mediaType = "application/yaml",
+                                                schema = @Schema( implementation = ContinentDTO.class ) ),
+                                      @Content( mediaType = "application/xml",
+                                                schema = @Schema( implementation = ContinentDTO.class ) )
+                                  }
+                    )
+                },
                 parameters = {
-                        @Parameter( name = "code", required = true, in = ParameterIn.PATH, description = "2 character code" ),
+                        @Parameter( name = "code",
+                                    required = true,
+                                    in = ParameterIn.PATH,
+                                    description = "2 character code" ),
                         @Parameter( name = "TRACEPARENT",
                                     required = false,
                                     schema = @Schema( implementation = String.class ),
@@ -289,7 +294,7 @@ public class ContinentController
             // Build the resource id (path) of the newly created item
             final URI location = ServletUriComponentsBuilder
                     .fromCurrentRequest()
-                    .path("/{continentId}")
+                    .path( "/{continentId}" )
                     .buildAndExpand( continent.getId() )
                     .toUri();
             return ResponseEntity
@@ -462,20 +467,25 @@ public class ContinentController
     @Operation( method = "PATCH",
                 summary = "Update a Continent",
                 description = "Update a Continent only if it exists.  All non-null attributes are updated.",
-                requestBody = @RequestBody( required = true,
-                                            content = { @Content( mediaType = "application/json",
-                                                                  schema = @Schema( implementation = ContinentDTO.class ) )
-                                            }
+                requestBody =
+                    @RequestBody( required = true,
+                                  content = { @Content( mediaType = "application/json",
+                                                        schema = @Schema( implementation = ContinentDTO.class ) )
+                                  }
                 ),
-                responses = { @ApiResponse( description = "Continent updated and returned",
-                                            responseCode = "200",
-                                            content = { @Content( mediaType = "application/json",
-                                                                  schema = @Schema( implementation = ContinentDTO.class ) ),
-                                                        @Content( mediaType = "application/yaml",
-                                                                  schema = @Schema( implementation = ContinentDTO.class ) ),
-                                                        @Content( mediaType = "application/xml",
-                                                                  schema = @Schema( implementation = ContinentDTO.class ) )
-                                            }
+                responses = {
+                    @ApiResponse(
+                        description = "Continent updated and returned",
+                        responseCode = "200",
+                        content =
+                        {
+                            @Content( mediaType = "application/json",
+                                      schema = @Schema( implementation = ContinentDTO.class ) ),
+                            @Content( mediaType = "application/yaml",
+                                      schema = @Schema( implementation = ContinentDTO.class ) ),
+                            @Content( mediaType = "application/xml",
+                                      schema = @Schema( implementation = ContinentDTO.class ) )
+                        }
                     )
                 },
                 parameters = {

--- a/app/src/main/java/com/example/airline/location/continent/mapper/EntityMapHelper.java
+++ b/app/src/main/java/com/example/airline/location/continent/mapper/EntityMapHelper.java
@@ -40,7 +40,7 @@ public final class EntityMapHelper
 
 
     /*
-    public static <F,T> Optional<T> mapOptionalEntityToDomain( final Optional<F> from )
+    public static <F, T> Optional<T> mapOptionalEntityToDomain( final Optional<F> from )
     {
         if ( from.isPresent() )
         {

--- a/app/src/main/java/com/example/airline/location/region/model/Region.java
+++ b/app/src/main/java/com/example/airline/location/region/model/Region.java
@@ -29,7 +29,7 @@ public class Region
     private Integer id;
 
     /**
-     * local_code prefixed with the country code to make a globally-unique
+     * local_code prefixed with the country code to make a globally unique
      * identifier.
      */
     @NonNull private String code;
@@ -37,7 +37,7 @@ public class Region
     /**
      * The local code for the administrative subdivision. Whenever possible, these
      * are official ISO 3166:2, at the highest level available, but in some cases
-     * OurAirports has to use unofficial codes. There is also a pseudo code "U-A"
+     * OurAirports has to use unofficial codes. There is also a pseudocode "U-A"
      * for each country, which means that the airport has not yet been assigned to a
      * region (or perhaps can't be, as in the case of a deep-sea oil platform).
      */
@@ -45,7 +45,7 @@ public class Region
 
     /**
      * The common English-language name for the administrative subdivision. In some
-     * cases, the name in local languages will appear in the keywords field assist
+     * cases, the name in local languages will appear in the keyword field assist
      * search.
      */
     @NonNull private String name;
@@ -55,13 +55,13 @@ public class Region
      * administrative subdivision. A handful of unofficial, non-ISO codes are also
      * in use, such as "XK" for Kosovo.
      */
-    @NonNull private String country; // ! Create domain object for the country code
+    @NonNull private String country; // ! Create a domain object for the country code
 
     /**
      * A code for the continent to which the region belongs. See the continent field
      * in airports.csv for a list of codes.
      */
-    @NonNull private String continent; // ! Create domain object for contient code
+    @NonNull private String continent; // ! Create a domain object for continent code
 
     /**
      * A link to the Wikipedia article describing the subdivision.
@@ -69,7 +69,7 @@ public class Region
     @Nullable private URI wikipediaLink;
 
     /**
-     * A comma-separated list of keywords to assist with search. May include former
+     * A comma-separated list of keywords to help with search. May include former
      * names for the region, and/or the region name in other languages.
      */
     @Nullable private String keywords;

--- a/app/src/main/resources/application-dev-mysql.yml
+++ b/app/src/main/resources/application-dev-mysql.yml
@@ -1,4 +1,4 @@
-# Dev profile utilizes a DB server which could be local or on a dev server
+# Dev profile uses a DB server which could be local or on a dev server
 
 # TODO this should be in a local profile
 datasource:

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -1,4 +1,4 @@
-# Dev profile utilizes a DB server which could be local or on a dev server
+# Dev profile uses a DB server which could be local or on a dev server
 
 # TODO this should be in a local profile
 datasource:

--- a/app/src/main/resources/application-local.yml
+++ b/app/src/main/resources/application-local.yml
@@ -25,7 +25,7 @@ spring:
   jpa:
     hibernate:
       # none, validate, update, create, create-drop
-      ddl-auto: validate
+      ddlAuto: validate
       generateStatistics: true
 
     open-in-view: false

--- a/app/src/main/resources/application-local.yml
+++ b/app/src/main/resources/application-local.yml
@@ -25,7 +25,7 @@ spring:
   jpa:
     hibernate:
       # none, validate, update, create, create-drop
-      ddl-auto: none
+      ddl-auto: validate
       generateStatistics: true
 
     open-in-view: false
@@ -280,3 +280,13 @@ management:
   tracing:
     sampling:
       probability: 1.0
+
+
+# Configuration for Flexy Pool
+#decorator:
+#  datasource:
+#    flexyPool:
+#      threshold:
+#        connection:
+#          acquire: 1
+#          lease: 0

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -38,7 +38,7 @@ spring:
   liquibase:
     changeLog: classpath:db/changelog/db.changelog-master.yaml
 
-  # Datasource is defined in a profile specific application-<profile>.yaml
+  # Datasource is defined in a profile-specific application-<profile>.yaml
   datasource:
     driverClassName: ${datasource.driver.classname}
     url: ${datasource.url}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -18,6 +18,11 @@ spring:
     defaultPropertyInclusion: NON_NULL
 
   jpa:
+    hibernate:
+      # none, validate, update, create, create-drop
+      ddlAuto: validate
+      generateStatistics: true
+
     openInView: false
 
   profiles:
@@ -46,10 +51,6 @@ spring:
     password: ${datasource.password}
 
 
-#  jpa:
-#    hibernate:
-    # none, validate, update, create, create-drop
-#      ddl-auto: validate
 
     showSql: true
     properties:

--- a/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00001-Create-continents.yaml
+++ b/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00001-Create-continents.yaml
@@ -3,6 +3,12 @@ databaseChangeLog:
       id: "00005"
       author: kevin
       changes:
+        - createSequence:
+            sequenceName: seq_continent_id
+            #  Initial load of the table has 7 rows
+            startValue: 100
+            incrementBy: 1
+
         - createTable:
             tableName: continents
             remarks: Each row represents a country or country-like entity (e.g. Hong Kong). The iso_country column in airports.csv, navaids.csv, and regions.csv refer to the code column here.
@@ -11,7 +17,7 @@ databaseChangeLog:
               - column:
                   name: id
                   type: integer
-                  autoIncrement: true
+                  defaultValueSequenceNext: seq_continent_id
                   constraints:
                     primaryKey: true
                     nullable: false

--- a/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00002-Create-countries.yaml
+++ b/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00002-Create-countries.yaml
@@ -3,6 +3,12 @@ databaseChangeLog:
       id: "00006"
       author: kevin
       changes:
+        - createSequence:
+            sequenceName: seq_countries_id
+            #  Initial load of the table has 7 rows
+            startValue: 593723
+            incrementBy: 1
+
         - createTable:
             tableName: countries
             remarks: Each row represents a country or country-like entity (e.g. Hong Kong). The iso_country column in airports.csv, navaids.csv, and regions.csv refer to the code column here.
@@ -11,10 +17,12 @@ databaseChangeLog:
               - column:
                   name: id
                   type: integer
+                  defaultValueSequenceNext: seq_countries_id
                   constraints:
                     primaryKey: true
                     nullable: false
                   remarks: Internal OurAirports integer identifier for the country. This will stay persistent, even if the country name or code changes.
+
               - column:
                   name: code
                   type: char(2)

--- a/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00003-Create-regions.yaml
+++ b/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00003-Create-regions.yaml
@@ -3,6 +3,12 @@ databaseChangeLog:
       id: "00007"
       author: kevin
       changes:
+        - createSequence:
+            sequenceName: seq_regions_id
+            #  Initial load of the table has 7 rows
+            startValue: 595550
+            incrementBy: 1
+
         - createTable:
             tableName: regions
             remarks: Each row represents a high-level administrative subdivision of a country. The iso_region column in airports.csv links to the code column in this dataset.
@@ -11,10 +17,12 @@ databaseChangeLog:
               - column:
                   name: id
                   type: integer
+                  defaultValueSequenceNext: seq_regions_id
                   constraints:
                     primaryKey: true
                     nullable: false
                   remarks: Internal OurAirports integer identifier for the region. This will stay persistent, even if the region code changes.
+
               - column:
                   name: code
                   type: varchar(7)

--- a/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00004-Create-airports.yaml
+++ b/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00004-Create-airports.yaml
@@ -3,6 +3,11 @@ databaseChangeLog:
       id: "00008"
       author: kevin
       changes:
+        - createSequence:
+            sequenceName: airport_id_seq
+            startValue: 1
+            incrementBy: 1
+
         - createTable:
             tableName: airports
             remarks: Each row in this dataset represents the record for a single airport. The primary key for interoperability purposes with other datasets is ident, but the actual internal OurAirports primary key is id. iso_region is a foreign key into the regions.csv download file.
@@ -29,7 +34,7 @@ databaseChangeLog:
                   remarks: The type of the airport. Allowed values are "closed_airport", "heliport", "large_airport", "medium_airport", "seaplane_base", and "small_airport". See the map legend for a definition of each type.
               - column:
                   name: name
-                  # current max length is 108
+                  # the current max length is 108
                   type: varchar(128)
                   constraints:
                     nullable: false
@@ -70,10 +75,10 @@ databaseChangeLog:
                   remarks: The two-character ISO 3166:1-alpha2 code for the country where the airport is (primarily) located. A handful of unofficial, non-ISO codes are also in use, such as "XK" for Kosovo. Points to the code column in countries.csv.
               - column:
                   name: municipality
-                  # current max length is 61
+                  # the current max length is 61
                   type: varchar(80)
                   constraints:
-                    # There really should be municipality for every airport....
+                    # There really should be municipality for every airport
                     nullable: true
                   remarks: The primary municipality that the airport serves (when available). Note that this is not necessarily the municipality where the airport is physically located.
               # Actually a boolean

--- a/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00004-Create-airports.yaml
+++ b/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00004-Create-airports.yaml
@@ -4,8 +4,9 @@ databaseChangeLog:
       author: kevin
       changes:
         - createSequence:
-            sequenceName: airport_id_seq
-            startValue: 1
+            sequenceName: seq_airport_id
+            #  Initial load of the table has about 82,866 rows
+            startValue: 596214
             incrementBy: 1
 
         - createTable:
@@ -16,10 +17,12 @@ databaseChangeLog:
               - column:
                   name: id
                   type: bigint
+                  defaultValueSequenceNext: seq_airport_id
                   constraints:
                     primaryKey: true
                     nullable: false
                   remarks: Internal OurAirports integer identifier for the airport. This will stay persistent, even if the airport code changes.
+
               - column:
                   name: ident
                   type: varchar(8)
@@ -119,6 +122,15 @@ databaseChangeLog:
                   type: varchar(512)
                   remarks: Extra keywords/phrases to assist with search, comma-separated. May include former names for the airport, alternate codes, names in other languages, nearby tourist destinations, etc.
 
+
+        # ----- Airport_Kind -----
+        - createSequence:
+            sequenceName: seq_airport_kind_id
+            #  Initial load of the table has about 82,866 rows
+            startValue: 100
+            incrementBy: 5
+
+
         - createTable:
             tableName: airport_kind
             remarks: Each row represents a country or country-like entity (e.g. Hong Kong). The iso_country column in airports.csv, navaids.csv, and regions.csv refer to the code column here.
@@ -127,7 +139,7 @@ databaseChangeLog:
               - column:
                   name: id
                   type: integer
-                  autoIncrement: true
+                  defaultValueSequenceNext: seq_airport_kind_id
                   constraints:
                     primaryKey: true
                     nullable: false

--- a/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00005-Create-navaids.yaml
+++ b/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00005-Create-navaids.yaml
@@ -3,12 +3,20 @@ databaseChangeLog:
       id: "00009"
       author: kevin
       changes:
+        - createSequence:
+            sequenceName: seq_navaids_id
+            #  Initial load of the table has 7 rows
+            startValue: 100
+            incrementBy: 1
+
+
         - createTable:
             tableName: navaids
             columns:
               - column:
                   name: id
                   type: integer
+                  defaultValueSequenceNext: seq_navaids_id
                   constraints:
                     primaryKey: true
                     nullable: false
@@ -116,6 +124,12 @@ databaseChangeLog:
                     nullable: true
                   remarks: The OurAirports text identifier (usually the ICAO code) for an airport associated with the navaid. Links to the ident column in airports.csv.
 
+        - createSequence:
+            sequenceName: seq_navaids_kind_id
+            #  Initial load of the table has 7 rows
+            startValue: 100
+            incrementBy: 1
+
         - createTable:
             tableName: navaid_kind
             remarks: Each row represents a classifier for navaids. The kind column in navaids.csv refers to the code column here.
@@ -124,7 +138,7 @@ databaseChangeLog:
               - column:
                   name: id
                   type: integer
-                  autoIncrement: true
+                  defaultValueSequenceNext: seq_navaids_kind_id
                   constraints:
                     primaryKey: true
                     nullable: false

--- a/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00006-Create-airport_frequencies.yaml
+++ b/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00006-Create-airport_frequencies.yaml
@@ -3,6 +3,12 @@ databaseChangeLog:
       id: "00010"
       author: kevin
       changes:
+        - createSequence:
+            sequenceName: seq_airport_frequencies_id
+            #  Initial load of the table has 7 rows
+            startValue: 596056
+            incrementBy: 1
+
         - createTable:
             tableName: airport_frequencies
             remarks: Each row in this dataset represents a single airport radio frequency for voice communication (radio navigation aids appear in navaids.csv). The column airport_ident is a foreign key referencing the ident column in airports.csv for the associated airport.
@@ -11,6 +17,7 @@ databaseChangeLog:
               - column:
                   name: id
                   type: integer
+                  defaultValueSequenceNext: seq_airport_frequencies_id
                   constraints:
                     primaryKey: true
                     nullable: false
@@ -52,6 +59,15 @@ databaseChangeLog:
                     nullable: false
                   remarks: Radio voice frequency in megahertz. Note that the same frequency may appear multiple times for an airport, serving different functions.
 
+
+
+        - createSequence:
+            sequenceName: seq_airport_frequency_kind_id
+            #  Initial load of the table has 7 rows
+            startValue: 596056
+            incrementBy: 1
+
+
         - createTable:
             tableName: airport_frequency_kind
             remarks: Each row represents a classifier for an aiport radio frequency.
@@ -60,7 +76,7 @@ databaseChangeLog:
               - column:
                   name: id
                   type: integer
-                  autoIncrement: true
+                  defaultValueSequenceNext: seq_airport_frequency_kind_id
                   constraints:
                     primaryKey: true
                     nullable: false

--- a/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00007-Create-runways.yaml
+++ b/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00007-Create-runways.yaml
@@ -3,6 +3,13 @@ databaseChangeLog:
       id: "00011"
       author: kevin
       changes:
+        - createSequence:
+            sequenceName: seq_runways_id
+            #  Initial load of the table has 7 rows
+            startValue: 596178
+            incrementBy: 1
+
+
         - createTable:
             tableName: runways
             remarks: Each row in this dataset represents a single airport landing surface (runway, helipad, or waterway). The initial fields apply to the entire surface, in both directions. Fields beginning with le_* apply only to the low-numbered end of the runway (e.g. 09), while fields beginning with he_* apply only to the high-numbered end of the runway (e.g. 27).
@@ -10,6 +17,7 @@ databaseChangeLog:
               - column:
                   name: id
                   type: integer
+                  defaultValueSequenceNext: seq_runways_id
                   constraints:
                     primaryKey: true
                     nullable: false
@@ -118,6 +126,12 @@ databaseChangeLog:
                   type: integer
                   remarks: Length of the displaced threshold (if any) for the high-numbered end of the runway, in feet.
 
+        - createSequence:
+            sequenceName: seq_runway_surface_kind_id
+            #  Initial load of the table has 7 rows
+            startValue: 100
+            incrementBy: 1
+
         - createTable:
             tableName: runway_surface_kind
             remarks: Each row represents a classifier for runway_surface_kind. The surface column in runways.csv refers to the kind column here.
@@ -126,7 +140,7 @@ databaseChangeLog:
               - column:
                   name: id
                   type: integer
-                  autoIncrement: true
+                  defaultValueSequenceNext: seq_runway_surface_kind_id
                   constraints:
                     primaryKey: true
                     nullable: false

--- a/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00008-Create-faa_abbreviations.yaml
+++ b/app/src/main/resources/db/changelog/00002-Robust-Airport-Data/00008-Create-faa_abbreviations.yaml
@@ -3,6 +3,12 @@ databaseChangeLog:
       id: "00012"
       author: kevin
       changes:
+        - createSequence:
+            sequenceName: seq_faa_abbreviations_id
+            #  Initial load of the table has 7 rows
+            startValue: 100
+            incrementBy: 1
+
         - createTable:
             tableName: faa_abbreviations
             remarks: Each row represents a classifier for an faa_abbreviation.
@@ -11,7 +17,7 @@ databaseChangeLog:
               - column:
                   name: id
                   type: integer
-                  autoIncrement: true
+                  defaultValueSequenceNext: seq_faa_abbreviations_id
                   constraints:
                     primaryKey: true
                     nullable: false

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -10,8 +10,8 @@
     Checkstyle is very configurable. Be sure to read the documentation at
     http://checkstyle.org (or in your downloaded distribution).
 
-    To completely disable a check, just comment it out or delete it from the file.
-    To suppress certain violations please review suppression filters.
+    To completely disable a check, comment it out or delete it from the file.
+    To suppress certain violations, please review suppression filters.
 
     Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
  -->

--- a/lib/src/main/java/com/example/airline/location/airport/persistence/model/AirportCodeIataEntity.java
+++ b/lib/src/main/java/com/example/airline/location/airport/persistence/model/AirportCodeIataEntity.java
@@ -13,7 +13,7 @@ import org.jspecify.annotations.NonNull;
 
 
 /**
- * Definition of operations on he IATA reference table.
+ * Definition of operations on the IATA reference table.
  */
 @Entity
 @Table( name = "iata_airportcode" )

--- a/lib/src/main/java/com/example/airline/location/airport/persistence/model/AirportCodeIcaoEntity.java
+++ b/lib/src/main/java/com/example/airline/location/airport/persistence/model/AirportCodeIcaoEntity.java
@@ -27,13 +27,4 @@ public class AirportCodeIcaoEntity
     @Column( name = "icao_code", length = 4, nullable = false, columnDefinition = "char(4)" )
     @NonNull private String icaoCode;
 
-    // /**
-    //  * Instantiate a ICAO airport code record.
-    //  *
-    //  * @param icaoCode the ICAO code string.
-    //  */
-    // public AirportCodeIcaoEntity( final String icaoCode )
-    // {
-    //     this.icaoCode = icaoCode;
-    // }
 }

--- a/lib/src/main/java/com/example/airline/location/airport/persistence/model/AirportEntity.java
+++ b/lib/src/main/java/com/example/airline/location/airport/persistence/model/AirportEntity.java
@@ -14,6 +14,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -45,7 +46,14 @@ public class AirportEntity // extends Auditable<String>
      * persistent, even if the airport code changes.
      */
     @Id
-    @GeneratedValue( strategy = GenerationType.AUTO )
+    // @GeneratedValue( strategy = GenerationType.AUTO )
+    @GeneratedValue( strategy = GenerationType.SEQUENCE, generator = "airport_id_seq" )
+    @SequenceGenerator( name = "airport_id_seq",
+                        sequenceName = "airport_id_seq",
+                        allocationSize = 1,
+                        initialValue = 1 )
+    // @GeneratedValue( strategy = GenerationType.IDENTITY )
+    // airport_id_seq
     @SuppressWarnings( "PMD.ShortVariable" )
     @Column( name = "id", nullable = false )
     @NonNull private Long id;

--- a/lib/src/main/java/com/example/airline/location/airport/persistence/model/AirportEntity.java
+++ b/lib/src/main/java/com/example/airline/location/airport/persistence/model/AirportEntity.java
@@ -47,13 +47,12 @@ public class AirportEntity // extends Auditable<String>
      */
     @Id
     // @GeneratedValue( strategy = GenerationType.AUTO )
-    @GeneratedValue( strategy = GenerationType.SEQUENCE, generator = "airport_id_seq" )
-    @SequenceGenerator( name = "airport_id_seq",
-                        sequenceName = "airport_id_seq",
+    @GeneratedValue( strategy = GenerationType.SEQUENCE, generator = "seq_airport_id" )
+    @SequenceGenerator( name = "seq_airport_id",
+                        sequenceName = "seq_airport_id",
                         allocationSize = 1,
-                        initialValue = 1 )
+                        initialValue = 596_214 )
     // @GeneratedValue( strategy = GenerationType.IDENTITY )
-    // airport_id_seq
     @SuppressWarnings( "PMD.ShortVariable" )
     @Column( name = "id", nullable = false )
     @NonNull private Long id;

--- a/lib/src/main/java/com/example/airline/location/airport/persistence/repository/AirportCodeIataRepository.java
+++ b/lib/src/main/java/com/example/airline/location/airport/persistence/repository/AirportCodeIataRepository.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Repository;
 public interface AirportCodeIataRepository extends PagingAndSortingRepository<AirportCodeIataEntity, String>
 {
     /**
-     * Lookup a IATA airport reference code by its code.
+     * Lookup an IATA airport reference code by its code.
      *
      * @param iataCode the code to locate.
      *

--- a/lib/src/main/java/com/example/airline/location/airport/persistence/repository/AirportCodeIcaoRepository.java
+++ b/lib/src/main/java/com/example/airline/location/airport/persistence/repository/AirportCodeIcaoRepository.java
@@ -24,7 +24,7 @@ public interface AirportCodeIcaoRepository extends PagingAndSortingRepository<Ai
 {
 
     /**
-     * Lookup a ICAO airport reference code by its code.
+     * Lookup an ICAO airport reference code by its code.
      *
      * @param icaoCode the code to locate.
      *

--- a/lib/src/main/java/com/example/airline/location/continent/persistence/model/ContinentEntity.java
+++ b/lib/src/main/java/com/example/airline/location/continent/persistence/model/ContinentEntity.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -31,7 +32,12 @@ import org.jspecify.annotations.Nullable;
 public class ContinentEntity
 {
     @Id
-    @GeneratedValue( strategy = GenerationType.IDENTITY )  // or GenerationType.SEQUENCE
+    // @GeneratedValue( strategy = GenerationType.IDENTITY )  // or GenerationType.SEQUENCE
+    @GeneratedValue( strategy = GenerationType.SEQUENCE, generator = "seq_continent_id" )
+    @SequenceGenerator( name = "seq_continent_id",
+                        sequenceName = "seq_continent_id",
+                        allocationSize = 1,
+                        initialValue = 1 )
     @Column( name = "id", nullable = false )
     @SuppressWarnings( "PMD.ShortVariable" )
     @NonNull

--- a/lib/src/main/java/com/example/airline/location/continent/persistence/repository/ContinentRepository.java
+++ b/lib/src/main/java/com/example/airline/location/continent/persistence/repository/ContinentRepository.java
@@ -24,7 +24,7 @@ public interface ContinentRepository extends JpaRepository<ContinentEntity, Inte
     /**
      * Determine if an element exists in the DB.
      *
-     * @param id must not be {@literal null}.
+     * @param continentId must not be {@literal null}.
      * @return true if the continent is found, false otherwise.
      */
     @Override

--- a/lib/src/main/java/com/example/airline/location/continent/persistence/repository/ContinentRepository.java
+++ b/lib/src/main/java/com/example/airline/location/continent/persistence/repository/ContinentRepository.java
@@ -52,7 +52,7 @@ public interface ContinentRepository extends JpaRepository<ContinentEntity, Inte
     @NonNull ContinentEntity getReferenceById( @NonNull Integer id );
 
     /**
-     * Find a single {@code Continent} by its 2 character code.
+     * Find a single {@code Continent} by its 2-character code.
      *
      * @param continentCode the 2-character continent code.
      *

--- a/lib/src/main/java/com/example/airline/location/region/persistence/model/RegionEntity.java
+++ b/lib/src/main/java/com/example/airline/location/region/persistence/model/RegionEntity.java
@@ -40,7 +40,7 @@ public class RegionEntity
     @NonNull private Integer id;
 
     /**
-     * local_code prefixed with the country code to make a globally-unique
+     * local_code prefixed with the country code to make a globally unique
      * identifier.
      */
     @Column( name = "code", length = 7, nullable = false )
@@ -49,7 +49,7 @@ public class RegionEntity
     /**
      * The local code for the administrative subdivision. Whenever possible, these
      * are official ISO 3166:2, at the highest level available, but in some cases
-     * OurAirports has to use unofficial codes. There is also a pseudo code "U-A"
+     * OurAirports has to use unofficial codes. There is also a pseudocode "U-A"
      * for each country, which means that the airport has not yet been assigned to a
      * region (or perhaps can't be, as in the case of a deep-sea oil platform).
      */
@@ -58,7 +58,7 @@ public class RegionEntity
 
     /**
      * The common English-language name for the administrative subdivision. In some
-     * cases, the name in local languages will appear in the keywords field assist
+     * cases, the name in local languages will appear in the keyword field assist
      * search.
      */
     @Column( name = "name", length = 52, nullable = false )
@@ -70,14 +70,14 @@ public class RegionEntity
      * in use, such as "XK" for Kosovo.
      */
     @Column( name = "iso_country", length = 2, nullable = false, columnDefinition = "char(2)" )
-    @NonNull private String country; // ! Create domain object for the country code
+    @NonNull private String country; // ! Create a domain object for the country code
 
     /**
      * A code for the continent to which the region belongs. See the continent field
      * in airports.csv for a list of codes.
      */
     @Column( name = "continent", length = 2, nullable = false, columnDefinition = "char(2)" )
-    @NonNull private String continent; // ! Create domain object for contient code
+    @NonNull private String continent; // ! Create a domain object for continent code
 
     /**
      * A link to the Wikipedia article describing the subdivision.
@@ -87,7 +87,7 @@ public class RegionEntity
     @Nullable private URI wikipediaLink;
 
     /**
-     * A comma-separated list of keywords to assist with search. May include former
+     * A comma-separated list of keywords to help with search. May include former
      * names for the region, and/or the region name in other languages.
      */
     @Column( name = "keywords", length = 255 )

--- a/lib/src/main/java/com/example/utility/IgnoreCoverage.java
+++ b/lib/src/main/java/com/example/utility/IgnoreCoverage.java
@@ -15,8 +15,8 @@ import java.lang.annotation.Target;
 
 /**
  * Custom annotation which can be applied to a class or method to ignore the
- * annotated element from code coverage analysis. Use only when absolutely
- * necessary. For example on Application.main()
+ * annotated element from code coverage analysis. Use only when necessary.
+ * For example on Application.main()
  */
 @Documented
 @Retention( RUNTIME )

--- a/lib/src/main/java/com/example/utility/NumberFormat.java
+++ b/lib/src/main/java/com/example/utility/NumberFormat.java
@@ -7,7 +7,7 @@ package com.example.utility;
  * Utility for formating numbers.
  *
  * <p>
- * For readabilty the bit string may group bits together with an intervening
+ * For readabilty, the bit string may group bits together with an intervening
  * space.
  * <table border="1" style="border-collapse:collapse;">
  * <caption>Bit strings for the hexadecimal value <b>0xFACE</b></caption>
@@ -114,7 +114,7 @@ public final class NumberFormat
 
         final StringBuilder result = new StringBuilder();
 
-        // build the formatted string 1 bit at a time.
+        // Build the formatted string 1 bit at a time.
         // Test LSB and shift right for next iteration
         long value = number;
         for ( int i = bits - 1; i >= 0; i-- )

--- a/lib/src/main/java/com/example/utility/NumberFormat.java
+++ b/lib/src/main/java/com/example/utility/NumberFormat.java
@@ -6,10 +6,9 @@ package com.example.utility;
 /**
  * Utility for formating numbers.
  *
+ * <p>
  * For readabilty the bit string may group bits together with an intervening
  * space.
- *
- * <p>
  * <table border="1" style="border-collapse:collapse;">
  * <caption>Bit strings for the hexadecimal value <b>0xFACE</b></caption>
  * <thead>

--- a/lib/src/main/java/com/example/utility/Stopwatch.java
+++ b/lib/src/main/java/com/example/utility/Stopwatch.java
@@ -40,7 +40,7 @@ public class Stopwatch implements AutoCloseable
      * @param service   typically it is the name of the REST/SOAP service.
      * @param method    the method/function that is being timed.
      * @param context   a unique
-     * @param autoStart true it will start the timer on instantiation.
+     * @param autoStart true, it will start the timer on instantiation.
      */
     public Stopwatch( final String service, final String method, final String context, final boolean autoStart )
     {

--- a/lib/src/main/java/com/example/utility/StringUtility.java
+++ b/lib/src/main/java/com/example/utility/StringUtility.java
@@ -25,7 +25,7 @@ public final class StringUtility
      * Null safe check if a {@code substring} is found within (@code target}.
      *
      * @param target   the string to examine.
-     * @param criteria the possible sub-string.
+     * @param criteria the possible substring.
      * @return true if the substring is found, false otherwise.
      */
     public static boolean nullSafeContains( @Nullable final String target,

--- a/lib/src/main/java/com/example/utility/ValidateUtilityClass.java
+++ b/lib/src/main/java/com/example/utility/ValidateUtilityClass.java
@@ -19,7 +19,7 @@ import org.apache.logging.log4j.Logger;
 
 // internal methods would be better as private, but that makes testing them
 // more difficult as they are only accessible via the one public method and
-// can not be exercised sufficiently to survive mutation tests.
+// cannot be exercised sufficiently to survive mutation tests.
 
 
 

--- a/lib/src/test/java/com/example/utility/StopwatchTest.java
+++ b/lib/src/test/java/com/example/utility/StopwatchTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 
 
 /**
- * Unit tests fro the {@code Stopwatch} timer.
+ * Unit tests for the {@code Stopwatch} timer.
  */
 // intentional practice to use literals in tests for clarity instead of chasing
 // down constant symbols

--- a/lib/src/test/java/com/example/utility/StringUtilityTest.java
+++ b/lib/src/test/java/com/example/utility/StringUtilityTest.java
@@ -165,7 +165,7 @@ class StringUtilityTest
             }
         }
 
-        /** Is the target string one of a set of possibilities. */
+        /** Is the target string one of a set of possibilities? */
         @DisplayName( "value not in collection:" )
         @ParameterizedTest( name = "({0}) not in: ({1})" )
         @ArgumentsSource( SubstringNotIncluded.class )

--- a/lib/src/test/java/com/example/utility/ValidateUtilityClassTest.java
+++ b/lib/src/test/java/com/example/utility/ValidateUtilityClassTest.java
@@ -96,7 +96,7 @@ class ValidateUtilityClassTest
 
 
 
-        /** condition the test is looking for as a cause of failure. */
+        /** The condition the test is looking for as a cause of failure. */
         @SuppressWarnings( { "PMD.UnusedFormalParameter" } )
         private MultipleConstructors( int dummy )
         {
@@ -175,7 +175,7 @@ class ValidateUtilityClassTest
     }
 
     /**
-     * Input class to generate InstantationException when validating behavior of
+     * Input class to generate InstantationException when validating the behavior of
      * constructor check.
      */
     @SuppressWarnings( "PMD.ClassWithOnlyPrivateConstructorsShouldBeFinal" )


### PR DESCRIPTION
Hibernate validate DB set.  This 'required' some changes to the DDL to include sequence definitions for table primary keys.
The keys could have all been Identity and not required the sequence.  This is part of the over-engineering to include features as reference.
